### PR TITLE
Add `otp` Type

### DIFF
--- a/PURL-TYPES.rst
+++ b/PURL-TYPES.rst
@@ -481,6 +481,39 @@ including container images built by Docker and others:
       pkg:oci/static@sha256%3A244fd47e07d10?repository_url=gcr.io/distroless/static&tag=latest
       pkg:oci/hello-wasm@sha256%3A244fd47e07d10?tag=v1
 
+otp
+---
+``otp`` for BEAM/OTP applications written in **Elixir, Erlang, Gleam** and
+other BEAM languages:
+
+- If the component was fetched from a **Hex** repository, prefer a ``hex`` purl
+  because Hex provides a global, collision-free namespace that uniquely ties
+  the version to the published source.
+- There is **no default package repository**. When the application can be
+  fetched from a known location, add a general qualifier such as
+  ``repository_url``, ``download_url`` or ``vcs_url``.
+- The ``namespace`` component is **unused** and **MUST** be empty.
+- The ``name`` is the OTP *application name* from the ``.app`` file; it is
+  case-insensitive and **MUST** be lower-cased.
+- The ``version`` is the OTP *application version* (the ``vsn`` attribute).
+- **Optional qualifiers**  
+  ``platform`` - target operating system for native code (e.g. ``linux``,
+  ``darwin``, ``freebsd``, ``sunos``, ``win32``; case-insensitive).  
+  ``arch`` - target CPU architecture (e.g. ``amd64``, ``x86_64``, ``arm64``,
+  ``armv7``; case-insensitive).
+- A purl *subpath* (``#…``) may be added to reference a specific file or
+  directory inside the OTP application.
+- Examples::
+
+      pkg:otp/erts@10.6.3?platform=linux&arch=amd64&repository_url=https://github.com/erlang/otp&vcs_url=git%20https://github.com/erlang/otp.git
+      pkg:otp/stdlib@3.11.2?repository_url=https://github.com/erlang/otp&vcs_url=git%20https://github.com/erlang/otp.git
+      pkg:otp/crypto@4.6.4?platform=darwin&arch=x86_64&repository_url=https://github.com/erlang/otp&vcs_url=git%20https://github.com/erlang/otp.git
+      pkg:otp/elixir@1.10.0?repository_url=https://github.com/elixir-lang/elixir&vcs_url=git%20https://github.com/elixir-lang/elixir.git
+      pkg:otp/eex@1.10.0?repository_url=https://github.com/elixir-lang/elixir&vcs_url=git%20https://github.com/elixir-lang/elixir.git
+      pkg:otp/logger@1.10.0?repository_url=https://github.com/elixir-lang/elixir&vcs_url=git%20https://github.com/elixir-lang/elixir.git
+      pkg:otp/rebar@3.13.0?repository_url=https://github.com/erlang/rebar3&vcs_url=git%20https://github.com/erlang/rebar3.git
+      pkg:otp/hex@2.1.1?repository_url=https://github.com/hexpm/hex&vcs_url=git%20https://github.com/hexpm/hex.git
+
 pub
 ----
 ``pub`` for Dart and Flutter packages:


### PR DESCRIPTION
## Motivation

BEAM projects regularly depend on OTP **applications** that are *themselves*
missing from any package manager:

* The Erlang/OTP runtime shipped by a Linux distro is often outdated.  
  Teams pin a newer runtime built with **kerl** or **asdf**, or bundle it in
  their release artefact.
* Core language tooling (e.g. **Elixir**, **Rebar3**, **Hex**) is an OTP
  application too, yet it is rarely delivered by system package managers.
* Because these components do **not** come from Hex, their SBOM entry cannot
  be a `hex` purl; nor can it be a distro purl such as `deb`, `rpm`, `alpm`.

Today we have to fall back to a generic or VCS purl, which loses precision
(versioned app vs. tag/commit, selective patching, etc.).  
The **`otp` purl type** fills this gap.

## Decision flow

When a tool can emit **only one** purl per package (e.g. GitHub Dependency
Graph), follow this flowchart:

```mermaid
flowchart TD
    PM{"From Package Manager?
    rebar3 / mix"}
    OSPM{"From OS Package Manager?"}
    SCM{"Source (SCM)?"}
    GH["pkg:github/{owner}/{repo}"]
    BB["pkg:bitbucket/{owner}/{repo}"]
    Specific["pkg:{type}..."]
    PossiblyOtp{"OTP App?"}
    OTP["pkg:otp/{name}@{version}?vcs_url=git+https://{git}"]
    Generic["pkg:generic/...?vcs_url=git+https://{git}"]
    Hex["pkg:hex/{name}@{version}"]
    Git["Git"]
    OS["pkg:{alpm|deb|rpm}/..."]

    PM -- Yes --> SCM
    PM -- No --> OSPM
    OSPM -- No --> OTP
    OSPM -- Yes --> OS
    SCM -- Hex.SCM --> Hex
    SCM -- Mix.SCM.Git --> Git
    Git -- GitHub --> GH
    Git -- Bitbucket --> BB
    Git -- Other Specific --> Specific
    Git -- None --> PossiblyOtp
    SCM -- Mix.SCM.Path --> PossiblyOtp
    PossiblyOtp -- No --> Generic
    PossiblyOtp -- Yes --> OTP
```

When multiple purls **can** be recorded (e.g. SPDX, CycloneDX) you may attach
_both_ the `otp` purl and an additional purl (Git, GitHub, checksum, …) for
maximum traceability.

## Summary of the new type

| Field          | Rule                                                                 |
|----------------|----------------------------------------------------------------------|
| **type**       | `otp`                                                                |
| **namespace**  | *unused* – **must** be empty                                         |
| **name**       | OTP application name (from `.app`), lower‑cased                      |
| **version**    | Application version (`vsn`)                                          |
| **qualifiers** | `platform`, `arch`, plus generic qualifiers (`repository_url`, …)    |
| **subpath**    | May reference a file/dir inside the application                      |

> **Prefer `hex` when you can**  
> If the package truly originates from a Hex repo, emit a `hex` purl instead of
> `otp`. Hex’s global namespace all but eliminates name collisions.


## Concrete examples

```text
pkg:otp/erts@10.6.3?platform=linux&arch=amd64&\
repository_url=https://github.com/erlang/otp&\
vcs_url=git%20https://github.com/erlang/otp.git

pkg:otp/stdlib@3.11.2?repository_url=https://github.com/erlang/otp&\
vcs_url=git%20https://github.com/erlang/otp.git

pkg:otp/crypto@4.6.4?platform=darwin&arch=x86_64&\
repository_url=https://github.com/erlang/otp&\
vcs_url=git%20https://github.com/erlang/otp.git

pkg:otp/elixir@1.10.0?repository_url=https://github.com/elixir-lang/elixir&\
vcs_url=git%20https://github.com/elixir-lang/elixir.git

pkg:otp/rebar@3.13.0?repository_url=https://github.com/erlang/rebar3&\
vcs_url=git%20https://github.com/erlang/rebar3.git

pkg:otp/hex@2.1.1?repository_url=https://github.com/hexpm/hex&\
vcs_url=git%20https://github.com/hexpm/hex.git
```